### PR TITLE
PHP Parameters confused with string

### DIFF
--- a/colors/peacock.xml
+++ b/colors/peacock.xml
@@ -2493,7 +2493,7 @@
         </option>
         <option name="PHP_PARAMETER">
             <value>
-                <option name="FOREGROUND" value="bcd42a"/>
+                <option name="FOREGROUND" value="ff5d38"/>
             </value>
         </option>
         <option name="PHP_PARENTHESES">


### PR DESCRIPTION
PHP Parameters match string colouring and this makes it difficult to easily spot parameters in a string
`"The {$param} would look like it's part of the string"`