### PR TITLE
Correct Blink Light parent schema

### DIFF
--- a/colors/blink-light.xml
+++ b/colors/blink-light.xml
@@ -24,7 +24,7 @@
   ~
   -->
 
-<scheme name="Blink Light (rainglow)" version="1" parent_scheme="Darcula">
+<scheme name="Blink Light (rainglow)" version="1" parent_scheme="Default">
     <option name="FONT_SCALE" value="1.0"/>
     <metaInfo>
         <property name="created">2017-12-13T12:00:00</property>


### PR DESCRIPTION
It causes horizontal scrollbars to have a dark theme